### PR TITLE
Add skin tones and genders to tiny_bus_stop.json

### DIFF
--- a/tiny_bus_stop.json
+++ b/tiny_bus_stop.json
@@ -6,6 +6,23 @@
   "morespots": ["", "#spot##spot##spot##spot#"],
   "bus": ["🚌", "🚎"],
   "gap": ["　"],
-  "person": ["🚶", "🏃", "💃", "🕴","👫","👬","👭"],
-  "house": ["🏛", "🏚", "🏠", "🏡","⛪", "🕌", "🕍", "🏢", "🏣", "🏤", "🏥","🏦","🏨","🏩","🏪","🏫","🏬"]
+  "house": ["🏛", "🏚", "🏠", "🏡","⛪", "🕌", "🕍", "🏢", "🏣", "🏤", "🏥","🏦","🏨","🏩","🏪","🏫","🏬"],
+
+  "person": ["#person1#", "#person2#", "#person3#"],
+
+  "person1": ["#person1base##skintone##zwj##gender##vs16#"],
+  "person1base": ["🚶", "🏃"],
+
+  "person2": ["#person2base##skintone#"],
+  "_person2base-comment": ["Omit Woman in Business Suit Levitating: 'This Emoji ZWJ Sequence has not been Recommended For General Interchange (RGI) by Unicode. Expect limited cross-platform support'"],
+  "person2base": ["💃", "🕺", "🕴"],
+
+  "_holding-hands-comment": "Skin tone is new in Emoji 12.0 in 2019, will wait longer for wider support",
+  "person3": ["👫","👬","👭"],
+
+  "skintone": ["", "🏻", "🏼", "🏽", "🏾", "🏿"],
+  "zwj": ["‍"],
+  "_gender-comment": "Non-gendered version omitted because: 'Person Walking/Running: This emoji does not specify a gender, but is shown as a man on most platforms'",
+  "gender": ["♀️", "♂️"],
+  "vs16": ["️"]
 }


### PR DESCRIPTION
Where available, add different skin tones and genders for the people waiting (or running or dancing) for the bus.

Notes:

* 🚶and 🏃 can have skin tone and gender modifiers

* 💃, 🕺and 🕴can have a skin tone modifier, but not gender as it's already part of the emoji design

* Omit Woman in Business Suit Levitating (🕴️‍♀️): 'This Emoji ZWJ Sequence has not been Recommended For General Interchange (RGI) by Unicode. Expect limited cross-platform support.'

* Include the unspecified skin tone, this is usually yellow

* Female and male genders are included. Omit the unspecified gender versions, because they are usually shown as a man.
