### PR TITLE
Revert "More skin tone and gender combos holding hands"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-json

--- a/tiny_bus_stop.json
+++ b/tiny_bus_stop.json
@@ -17,18 +17,14 @@
   "_person2base-comment": ["Omit Woman in Business Suit Levitating: 'This Emoji ZWJ Sequence has not been Recommended For General Interchange (RGI) by Unicode. Expect limited cross-platform support'"],
   "person2base": ["💃", "🕺", "🕴"],
 
-  "person3": ["#person3a#", "#person3b#"],
-  "person3a": ["#person3a_base##skintone2##zwj#🤝#zwj##person3a_base##skintone2#"],
-  "person3a_base": ["🧑"],
-  "person3b": ["#person3b_base##skintone2##zwj#🤝#zwj##person3b_base##skintone2#"],
-  "person3b_base": ["👨", "👩"],
+  "person3": ["#person3base##skintone#"],
+  "person3base": ["👫","👬","👭"],
 
   "person4": ["#person4base##zwj##person4thing#"],
   "person4base": ["🧑#skintone#"],
   "person4thing": ["🦯", "🦼", "🦽"],
 
   "skintone": ["", "🏻", "🏼", "🏽", "🏾", "🏿"],
-  "skintone2": ["🏻", "🏼", "🏽", "🏾", "🏿"],
   "zwj": ["‍"],
   "_gender-comment": "Non-gendered version omitted because: 'Person Walking/Running: This emoji does not specify a gender, but is shown as a man on most platforms'",
   "gender": ["♀️", "♂️"],


### PR DESCRIPTION
This reverts commit 3d635b6 because some of the combos are a bit too new and not yet fully supported:

<img width="581" alt="image" src="https://user-images.githubusercontent.com/1324225/204153926-e8cf5b29-cfbc-4f7c-b047-20a84b425657.png">


https://botsin.space/@tiny_bus_stop/109415827713419908
https://botsin.space/@tiny_bus_stop/109412995760630726